### PR TITLE
HasBadge and heroicon bugfix

### DIFF
--- a/resources/views/components/accordion/item.blade.php
+++ b/resources/views/components/accordion/item.blade.php
@@ -36,7 +36,7 @@
             {{ $label }}
         </span>
         <span :class="{ 'rotate-180': activeAccordion == id }">
-            @svg('heroicon-c-chevron-down','w-4 h-4 duration-200 ease-out')
+            @svg('heroicon-m-chevron-down','w-4 h-4 duration-200 ease-out')
         </span>
     </button>
     <div class="p-4" x-show="activeAccordion == id" x-collapse x-cloak>

--- a/src/Forms/Accordion.php
+++ b/src/Forms/Accordion.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Str;
 
 class Accordion extends Component implements CanConcealComponents
 {
-    use HasBadge;
     use HasIcon;
 
     protected string $view = 'zeus-accordion::forms.accordion';
@@ -43,5 +42,12 @@ class Accordion extends Component implements CanConcealComponents
         $static->configure();
 
         return $static;
+    }
+
+    public function badge(string | Closure | null $badge): static
+    {
+        $this->badge = $badge;
+
+        return $this;
     }
 }

--- a/src/Forms/Accordion.php
+++ b/src/Forms/Accordion.php
@@ -5,7 +5,6 @@ namespace LaraZeus\Accordion\Forms;
 use Closure;
 use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Contracts\CanConcealComponents;
-use Filament\Support\Concerns\HasBadge;
 use Filament\Support\Concerns\HasIcon;
 use Illuminate\Support\Str;
 


### PR DESCRIPTION
 resolves two issues that were present (for me, at least) in a fresh install of Filament:
- 'HasBadge' trait seems not to exist. Default Filament Tab component simply has a badge method, which was copied in here and references to 'HasBadge' were removed
- item blade view file referenced a heroicon that does not appear to exist. Modified to a similar icon that exists within the bladeicons pack